### PR TITLE
タグ一覧ページの追加

### DIFF
--- a/themes/t2-lab/assets/css/main.css
+++ b/themes/t2-lab/assets/css/main.css
@@ -89,3 +89,11 @@
 .content-body pre button {
   @apply absolute top-2 right-2 z-10 hidden group-hover:block;
 }
+
+.tag-cloud {
+  @apply flex flex-wrap gap-2 mb-6 leading-relaxed;
+}
+
+.tag-cloud a {
+  @apply text-claude-accent-light hover:underline mr-2;
+}

--- a/themes/t2-lab/layouts/_default/terms.html
+++ b/themes/t2-lab/layouts/_default/terms.html
@@ -1,0 +1,27 @@
+{{ define "main" }}
+<h1 class="text-3xl text-claude-text-light font-bold mb-6" data-scramble>
+  {{ .Title }}
+</h1>
+<div class="tag-cloud">
+  {{ range $tag, $pages := .Site.Taxonomies.tags }}
+    {{ $count := len $pages }}
+    {{ $class := "" }}
+    {{ if lt $count 2 }}
+      {{ $class = "text-xs" }}
+    {{ else if lt $count 4 }}
+      {{ $class = "text-sm" }}
+    {{ else if lt $count 6 }}
+      {{ $class = "text-base" }}
+    {{ else if lt $count 8 }}
+      {{ $class = "text-lg" }}
+    {{ else if lt $count 10 }}
+      {{ $class = "text-xl" }}
+    {{ else }}
+      {{ $class = "text-2xl" }}
+    {{ end }}
+    <a href="/tags/{{ $tag | urlize }}/" class="{{ $class }}">
+      {{ $tag }}
+    </a>
+  {{ end }}
+</div>
+{{ end }}


### PR DESCRIPTION
## Summary
- add `terms.html` under `_default` for custom tag cloud page
- adjust Tailwind size classes based on tag count
- add `.tag-cloud` styles to `main.css`

## Testing
- `hugo server` *(fails: function "try" not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684d3e2f5a1483268f28bc21766d3487